### PR TITLE
fixes #24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install scikit-learn
 RUN pip install librosa
 RUN apt-get install -y libhdf5-dev
 RUN pip install h5py
-RUN pip install tqdm
+
 # ALE
 RUN apt-get install -y libsdl1.2-dev libsdl-gfx1.2-dev libsdl-image1.2-dev cmake
 RUN git clone https://github.com/mgbellemare/Arcade-Learning-Environment.git /tmp/ALE

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -29,7 +29,7 @@ You'll want to install the following list of packages. (You may have several of 
  - scikit-learn ([MemNet](/models/#memnet), [Speech](/models/#speech), [Autoenc](/models/#autoenc))
  - six ([Seq2Seq](/models/#seq2seq))
  - librosa ([Speech](/models/#speech))
- - tqdm ([Speech](/models/#speech))
+ <!-- - tqdm ([Speech](/models/#speech)) -->
  - h5py* ([Speech](/models/#speech))
 
 *For h5py, you'll also need libhdf5, which is the C++ backend for interfacing with HDF5-formatted files. This is usually available as a Linux package, but [building from source](https://support.hdfgroup.org/downloads/index.html) is also fine. Any recent version should work. In Ubuntu, the package you're looking for is `libhdf5-dev`.

--- a/fathom/speech/preproc.py
+++ b/fathom/speech/preproc.py
@@ -8,7 +8,6 @@ import librosa
 import sklearn.preprocessing
 import h5py
 import logging
-from tqdm import tqdm # progress bar
 
 import os
 import fnmatch
@@ -116,7 +115,7 @@ def compute_spectrograms(audio_filenames):
   features_list = []
   audio_ext = ".WAV"
 
-  for audio_basename in tqdm(audio_filenames):
+  for audio_basename in audio_filenames:
     # recompute spectrogram features
     # FIXME: on interrupt, kill the thread which librosa launches via audioread
     feature_vector = mfcc_features(audio_basename + audio_ext)


### PR DESCRIPTION
Just getting rid of the `tqdm` in the following files:
-  Dockerfile
-  docs/quickstart.md
-  fathom/speech/preproc.py

This is a minor change