### PR TITLE
Upgrade to tensorflow 1.0.x

### DIFF
--- a/fathom/autoenc/autoenc.py
+++ b/fathom/autoenc/autoenc.py
@@ -144,7 +144,7 @@ class AutoencBase(NeuralNetworkModel):
 
   def build_loss(self, inputs, reconstruction):
     with self.G.as_default():
-      self.loss_op = 0.5 * tf.reduce_sum(tf.pow(tf.sub(reconstruction, inputs), 2.0))
+      self.loss_op = 0.5 * tf.reduce_sum(tf.pow(tf.subtract(reconstruction, inputs), 2.0))
     return self.loss_op
 
   @property

--- a/fathom/autoenc/variational.py
+++ b/fathom/autoenc/variational.py
@@ -22,8 +22,8 @@ class Autoenc(AutoencBase):
       self.z_log_sigma_sq = tf.add(tf.matmul(inputs, self.weights['log_sigma_w1']), self.weights['log_sigma_b1'])
 
       # sample from gaussian distribution
-      eps = tf.random_normal(tf.pack([tf.shape(self.xs)[0], self.n_hidden]), 0, 1, dtype = tf.float32)
-      self.z = tf.add(self.z_mean, tf.mul(tf.sqrt(tf.exp(self.z_log_sigma_sq)), eps))
+      eps = tf.random_normal(tf.stack([tf.shape(self.xs)[0], self.n_hidden]), 0, 1, dtype = tf.float32)
+      self.z = tf.add(self.z_mean, tf.multiply(tf.sqrt(tf.exp(self.z_log_sigma_sq)), eps))
 
       self.reconstruction = tf.add(tf.matmul(self.z, self.weights['w2']), self.weights['b2'])
 
@@ -35,7 +35,7 @@ class Autoenc(AutoencBase):
   def build_loss(self, inputs, reconstruction):
     with self.G.as_default():
       # cost
-      reconstr_loss = 0.5 * tf.reduce_sum(tf.pow(tf.sub(self.reconstruction, self.xs), 2.0))
+      reconstr_loss = 0.5 * tf.reduce_sum(tf.pow(tf.subtract(self.reconstruction, self.xs), 2.0))
       latent_loss = -0.5 * tf.reduce_sum(1 + self.z_log_sigma_sq
                                          - tf.square(self.z_mean)
                                          - tf.exp(self.z_log_sigma_sq), 1)

--- a/fathom/deepq/deepq.py
+++ b/fathom/deepq/deepq.py
@@ -131,22 +131,22 @@ class DeepQNetNature(object):
 
       #Q,Cost,Optimizer
       self.discount = tf.constant(self.params['discount'])
-      self.yj = tf.add(self.rewards, tf.mul(1.0-self.terminals, tf.mul(self.discount, self.q_t)))
-      self.Qxa = tf.mul(self.y,self.actions)
-      self.Q_pred = tf.reduce_max(self.Qxa, reduction_indices=1)
+      self.yj = tf.add(self.rewards, tf.multiply(1.0-self.terminals, tf.multiply(self.discount, self.q_t)))
+      self.Qxa = tf.multiply(self.y,self.actions)
+      self.Q_pred = tf.reduce_max(self.Qxa, axis=1)
       #self.yjr = tf.reshape(self.yj,(-1,1))
       #self.yjtile = tf.concat(1,[self.yjr,self.yjr,self.yjr,self.yjr])
       #self.yjax = tf.mul(self.yjtile,self.actions)
 
       #half = tf.constant(0.5)
-      self.diff = tf.sub(self.yj, self.Q_pred)
+      self.diff = tf.subtract(self.yj, self.Q_pred)
       if self.params['clip_delta'] > 0 :
         self.quadratic_part = tf.minimum(tf.abs(self.diff), tf.constant(self.params['clip_delta']))
-        self.linear_part = tf.sub(tf.abs(self.diff),self.quadratic_part)
+        self.linear_part = tf.subtract(tf.abs(self.diff),self.quadratic_part)
         self.diff_square = 0.5 * tf.pow(self.quadratic_part,2) + self.params['clip_delta']*self.linear_part
 
       else:
-        self.diff_square = tf.mul(tf.constant(0.5),tf.pow(self.diff, 2))
+        self.diff_square = tf.multiply(tf.constant(0.5),tf.pow(self.diff, 2))
       # add optimization
 
       self.loss()
@@ -237,7 +237,7 @@ class DeepQ(GenericModel):
         self.setup_config.gpu_options.per_process_gpu_memory_fraction=self.params['gpu_fraction']
 
       self.sess = tf.Session(config=self.setup_config)
-      self.init = tf.initialize_all_variables()
+      self.init = tf.global_variables_initializer()
       self.sess.run(self.init)
       self.sess.run(self.cp_ops)
 

--- a/fathom/imagenet/image_processing.py
+++ b/fathom/imagenet/image_processing.py
@@ -143,7 +143,7 @@ def decode_jpeg(image_buffer, scope=None):
   Returns:
     3-D float Tensor with values ranging from [0, 1).
   """
-  with tf.op_scope([image_buffer], scope, 'decode_jpeg'):
+  with tf.name_scope(values=[image_buffer], name=scope, default_name='decode_jpeg'):
     # Decode the string as an RGB JPEG.
     # Note that the resulting image contains an unknown height and width
     # that is set dynamically by decode_jpeg. In other words, the height
@@ -172,7 +172,7 @@ def distort_color(image, thread_id=0, scope=None):
   Returns:
     color-distorted image
   """
-  with tf.op_scope([image], scope, 'distort_color'):
+  with tf.name_scope(values=[image], name=scope, default_name='distort_color'):
     color_ordering = thread_id % 2
 
     if color_ordering == 0:
@@ -210,7 +210,7 @@ def distort_image(image, height, width, bbox, thread_id=0, scope=None):
   Returns:
     3-D float Tensor of distorted image used for training.
   """
-  with tf.op_scope([image, height, width, bbox], scope, 'distort_image'):
+  with tf.name_scope(values=[image, height, width, bbox], name=scope, default_name='distort_image'):
     # Each bounding box has shape [1, num_boxes, box coords] and
     # the coordinates are ordered [ymin, xmin, ymax, xmax].
 
@@ -218,7 +218,7 @@ def distort_image(image, height, width, bbox, thread_id=0, scope=None):
     if not thread_id:
       image_with_box = tf.image.draw_bounding_boxes(tf.expand_dims(image, 0),
                                                     bbox)
-      tf.image_summary('image_with_bounding_boxes', image_with_box)
+      tf.summary.image('image_with_bounding_boxes', image_with_box)
 
   # A large fraction of image datasets contain a human-annotated bounding
   # box delineating the region of the image containing the object of interest.
@@ -239,7 +239,7 @@ def distort_image(image, height, width, bbox, thread_id=0, scope=None):
     if not thread_id:
       image_with_distorted_box = tf.image.draw_bounding_boxes(
           tf.expand_dims(image, 0), distort_bbox)
-      tf.image_summary('images_with_distorted_bounding_box',
+      tf.summary.image('images_with_distorted_bounding_box',
                        image_with_distorted_box)
 
     # Crop the image to the specified bounding box.
@@ -250,13 +250,13 @@ def distort_image(image, height, width, bbox, thread_id=0, scope=None):
     # fashion based on the thread number.
     # Note that ResizeMethod contains 4 enumerated resizing methods.
     resize_method = thread_id % 4
-    distorted_image = tf.image.resize_images(distorted_image, height, width,
+    distorted_image = tf.image.resize_images(distorted_image, [height, width],
                                              resize_method)
     # Restore the shape since the dynamic slice based upon the bbox_size loses
     # the third dimension.
     distorted_image.set_shape([height, width, 3])
     if not thread_id:
-      tf.image_summary('cropped_resized_image',
+      tf.summary.image('cropped_resized_image',
                        tf.expand_dims(distorted_image, 0))
 
     # Randomly flip the image horizontally.
@@ -266,7 +266,7 @@ def distort_image(image, height, width, bbox, thread_id=0, scope=None):
     distorted_image = distort_color(distorted_image, thread_id)
 
     if not thread_id:
-      tf.image_summary('final_distorted_image',
+      tf.summary.image('final_distorted_image',
                        tf.expand_dims(distorted_image, 0))
     return distorted_image
 
@@ -282,7 +282,7 @@ def eval_image(image, height, width, scope=None):
   Returns:
     3-D float Tensor of prepared image.
   """
-  with tf.op_scope([image, height, width], scope, 'eval_image'):
+  with tf.name_scope(values=[image, height, width], name=scope, default_name='eval_image'):
     # Crop the central region of the image with an area containing 87.5% of
     # the original image.
     image = tf.image.central_crop(image, central_fraction=0.875)
@@ -325,8 +325,8 @@ def image_preprocessing(image_buffer, bbox, train, thread_id=0):
     image = eval_image(image, height, width)
 
   # Finally, rescale to [-1,1] instead of [0, 1)
-  image = tf.sub(image, 0.5)
-  image = tf.mul(image, 2.0)
+  image = tf.subtract(image, 0.5)
+  image = tf.multiply(image, 2.0)
   return image
 
 
@@ -391,7 +391,7 @@ def parse_example_proto(example_serialized):
   ymax = tf.expand_dims(features['image/object/bbox/ymax'].values, 0)
 
   # Note that we impose an ordering of (y, x) just to make life difficult.
-  bbox = tf.concat(0, [ymin, xmin, ymax, xmax])
+  bbox = tf.concat(axis=0, values=[ymin, xmin, ymax, xmax])
 
   # Force the variable number of bounding boxes into the shape
   # [1, num_boxes, coords].
@@ -474,6 +474,6 @@ def batch_inputs(dataset, batch_size, train, num_preprocess_threads=None):
     images = tf.reshape(images, shape=[batch_size, height, width, depth])
 
     # Display the training images in the visualizer.
-    tf.image_summary('images', images)
+    tf.summary.image('images', images)
 
     return images, tf.reshape(label_index_batch, [batch_size])

--- a/fathom/imagenet/imagenet.py
+++ b/fathom/imagenet/imagenet.py
@@ -84,7 +84,7 @@ class ImagenetModel(NeuralNetworkModel):
     with self.G.as_default():
       # Define loss
       # TODO: does this labels have unexpected state?
-      self.loss_op = tf.reduce_mean(tf.nn.sparse_softmax_cross_entropy_with_logits(logits, labels))
+      self.loss_op = tf.reduce_mean(tf.nn.sparse_softmax_cross_entropy_with_logits(logits=logits, labels=labels))
     return self.loss_op
 
   def build_train(self, total_loss):

--- a/fathom/imagenet/mnist.py
+++ b/fathom/imagenet/mnist.py
@@ -24,7 +24,7 @@ def maybe_download(filename, work_directory):
   return filepath
 def _read32(bytestream):
   dt = numpy.dtype(numpy.uint32).newbyteorder('>')
-  return numpy.frombuffer(bytestream.read(4), dtype=dt)
+  return numpy.frombuffer(bytestream.read(4), dtype=dt)[0]
 def extract_images(filename):
   """Extract the images into a 4D uint8 numpy array [index, y, x, depth]."""
   print('Extracting', filename)

--- a/fathom/memnet/memnet.py
+++ b/fathom/memnet/memnet.py
@@ -20,8 +20,8 @@ class MemNet(NeuralNetworkModel):
       # variables
       #with tf.variable_scope(self.name):
       nil_word_slot = tf.zeros([1, self.embedding_size])
-      A = tf.concat(0, [ nil_word_slot, self.initializer([self.vocab_size-1, self.embedding_size]) ])
-      B = tf.concat(0, [ nil_word_slot, self.initializer([self.vocab_size-1, self.embedding_size]) ])
+      A = tf.concat(axis=0, values=[ nil_word_slot, self.initializer([self.vocab_size-1, self.embedding_size]) ])
+      B = tf.concat(axis=0, values=[ nil_word_slot, self.initializer([self.vocab_size-1, self.embedding_size]) ])
       self.A = tf.Variable(A, name="A")
       self.B = tf.Variable(B, name="B")
 
@@ -73,7 +73,7 @@ class MemNet(NeuralNetworkModel):
       with tf.name_scope('loss'):
         # Define loss
         # TODO: does this labels have unexpected state?
-        self.loss_op = tf.reduce_sum(tf.nn.softmax_cross_entropy_with_logits(logits, tf.cast(labels, tf.float32)))
+        self.loss_op = tf.reduce_sum(tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=tf.cast(labels, tf.float32)))
     return self.loss_op
 
   @property
@@ -243,11 +243,11 @@ def zero_nil_slot(t, name=None):
   The nil_slot is a dummy slot and should not be trained and influence
   the training algorithm.
   """
-  with tf.op_scope([t], name, "zero_nil_slot") as name:
+  with tf.name_scope(values=[t], name=name, default_name="zero_nil_slot") as name:
     t = tf.convert_to_tensor(t, name="t")
     s = tf.shape(t)[1]
-    z = tf.zeros(tf.pack([1, s]))
-    return tf.concat(0, [z, tf.slice(t, [1, 0], [-1, -1])], name=name)
+    z = tf.zeros(tf.stack([1, s]))
+    return tf.concat(axis=0, values=[z, tf.slice(t, [1, 0], [-1, -1])], name=name)
 
 def add_gradient_noise(t, stddev=1e-3, name=None):
   """
@@ -256,7 +256,7 @@ def add_gradient_noise(t, stddev=1e-3, name=None):
   The output will be `t` + gaussian noise.
   0.001 was said to be a good fixed value for memory networks [2].
   """
-  with tf.op_scope([t, stddev], name, "add_gradient_noise") as name:
+  with tf.name_scope(values=[t, stddev], name=name, default_name="add_gradient_noise") as name:
     t = tf.convert_to_tensor(t, name="t")
     gn = tf.random_normal(tf.shape(t), stddev=stddev)
     return tf.add(t, gn, name=name)

--- a/fathom/nn.py
+++ b/fathom/nn.py
@@ -45,7 +45,7 @@ class NeuralNetworkModel(GenericModel):
         self.build()
 
     with self.G.as_default():
-      self.init = tf.initialize_all_variables()
+      self.init = tf.global_variables_initializer()
 
   @abstractmethod
   def load_data(self):


### PR DESCRIPTION
This PR updates fathom to run with tensorflow 1.0.x. Changes have been made by the tf_upgrade script provided by tensorflow, with manual intervention where necessary.

Notes:
- seq2seq won't run on newer versions (1.1) of tensorflow, due to problems in tf.contrib.legacy_seq2seq (see https://github.com/tensorflow/tensorflow/issues/8191).
- speech hasn't been tested because I haven't been able to get a copy of its dataset.