### PR TITLE
Porting seq2seq to tensorflow versions later than 1.x

### DIFF
--- a/fathom/seq2seq/seq2seq.py
+++ b/fathom/seq2seq/seq2seq.py
@@ -78,7 +78,6 @@ class Seq2Seq(NeuralNetworkModel):
       def single_cell():
         if self.use_lstm:
             return tf.contrib.rnn.BasicLSTMCell(self.size, reuse=tf.get_variable_scope().reuse)
-            #return tf.contrib.rnn.BasicLSTMCell(self.size, reuse=tf.get_variable_scope().reuse)
         else:
             return tf.contrib.rnn.GRUCell(self.size, reuse=tf.get_variable_scope().reuse)
 

--- a/fathom/seq2seq/seq2seq.py
+++ b/fathom/seq2seq/seq2seq.py
@@ -76,16 +76,18 @@ class Seq2Seq(NeuralNetworkModel):
 
       # Create the internal multi-layer cell for our RNN.
       def single_cell():
-        return tf.contrib.rnn.GRUCell(self.size)
-      if self.use_lstm:
-        def single_cell():
-          return tf.contrib.rnn.BasicLSTMCell(self.size)
-      cell = single_cell()
-      if self.num_layers > 1:
-        cell = tf.contrib.rnn.MultiRNNCell([single_cell() for _ in range(self.num_layers)])
+        if self.use_lstm:
+            return tf.contrib.rnn.BasicLSTMCell(self.size, reuse=tf.get_variable_scope().reuse)
+            #return tf.contrib.rnn.BasicLSTMCell(self.size, reuse=tf.get_variable_scope().reuse)
+        else:
+            return tf.contrib.rnn.GRUCell(self.size, reuse=tf.get_variable_scope().reuse)
 
       # The seq2seq function: we use embedding for the input and attention.
       def seq2seq_f(encoder_inputs, decoder_inputs, do_decode):
+        if self.num_layers > 1:
+            cell = tf.contrib.rnn.MultiRNNCell([single_cell() for _ in range (self.num_layers)])
+        else:
+            cell = single_cell()
         return tf.contrib.legacy_seq2seq.embedding_attention_seq2seq(
             encoder_inputs, decoder_inputs, cell,
             num_encoder_symbols=self.source_vocab_size,


### PR DESCRIPTION
With the previous version of seq2seq you get the following error when trying to instantiate the class:
"""
Attempt to reuse RNNCell <tensorflow.contrib.rnn.python.ops.core_rnn_cell_impl.BasicLSTMCell object at 0x3fff26a85bd0> with a different variable scope than its first
use.  First use of cell was with scope 'embedding_attention_seq2seq/embedding_attention_decoder/attention_decoder/multi_rnn_cell/cell_0/basic_lstm_cell', this attempt is
with scope 'embedding_attention_seq2seq/rnn/multi_rnn_cell/cell_0/basic_lstm_cell'.  Please create a new instance of the cell if you would like it to use a different set
of weights.  If before you were using: MultiRNNCell([BasicLSTMCell(...)] * num_layers), change to: MultiRNNCell([BasicLSTMCell(...) for _ in range(num_layers)]).  If
before you were using the same cell instance as both the forward and reverse cell of a bidirectional RNN, simply create two instances (one for forward, one for
reverse).  In May 2017, we will start transitioning this cell's behavior to use existing stored weights, if any, when it is called with scope=None (which can lead to
silent model degradation, so this error will remain until then.)
"""

With the changes made, this error no longer appears and it is possible to instantiate the class successfully.